### PR TITLE
Add setup script for local testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,19 @@ This is a minimal Flask application that demonstrates logging in to Strava via O
 
 ## Setup
 
-1. Install dependencies:
-   ```bash
-   pip install -r requirements.txt
-   ```
-2. Create a [Strava application](https://www.strava.com/settings/api) and obtain your `Client ID` and `Client Secret`.
-3. Set the following environment variables:
+1. Create a [Strava application](https://www.strava.com/settings/api) and obtain your `Client ID` and `Client Secret`.
+2. Set the following environment variables (you can place them in a `.env` file):
    - `STRAVA_CLIENT_ID`
    - `STRAVA_CLIENT_SECRET`
    - `STRAVA_REDIRECT_URI` (optional, defaults to `http://localhost:5000/callback`)
    - `SECRET_KEY` (any random string for Flask sessions)
 
+The provided `setup.sh` script will create a virtual environment and install the requirements automatically.
+
 ## Running
 
 ```bash
-python app.py
+./setup.sh
 ```
 
-Then open `http://localhost:5000` in your browser and click "Connect with Strava".
+This command sets up a virtual environment (if needed), installs the dependencies and starts the server. Once running, open `http://localhost:5000` in your browser and click "Connect with Strava".

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -e
+
+# Create virtual environment if not present
+if [ ! -d venv ]; then
+    python3 -m venv venv
+fi
+
+# Activate virtual environment
+source venv/bin/activate
+
+# Install dependencies
+pip install -r requirements.txt
+
+# Load environment variables from .env if present
+if [ -f .env ]; then
+    export $(grep -v '^#' .env | xargs)
+fi
+
+# Ensure required variables are set
+: "${STRAVA_CLIENT_ID:?Set STRAVA_CLIENT_ID in environment or .env}"
+: "${STRAVA_CLIENT_SECRET:?Set STRAVA_CLIENT_SECRET in environment or .env}"
+: "${SECRET_KEY:?Set SECRET_KEY in environment or .env}"
+
+# Run the application
+python app.py


### PR DESCRIPTION
## Summary
- create `setup.sh` to set up venv, install dependencies and run the app
- document how to use the script in the README

## Testing
- `./setup.sh > /tmp/setup.log ; tail -n 5 /tmp/setup.log`

------
https://chatgpt.com/codex/tasks/task_e_68499cc426208328a341e9234bfdc6e2