### PR TITLE
Add environment template for Strava credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+STRAVA_CLIENT_ID=your_client_id_here
+STRAVA_CLIENT_SECRET=54b11041b6690a77f4ed1707e80a9f8f0ab0423a
+STRAVA_REDIRECT_URI=http://localhost:5000/callback
+SECRET_KEY=change_this_secret
+
+# Optional tokens (not required for OAuth flow)
+ACCESS_TOKEN=346fcd36f2ccb75983241c042de7fed53bf8f759
+REFRESH_TOKEN=047b58f1830e449852864086ac87d2f042a8399a

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a minimal Flask application that demonstrates logging in to Strava via O
 ## Setup
 
 1. Create a [Strava application](https://www.strava.com/settings/api) and obtain your `Client ID` and `Client Secret`.
-2. Set the following environment variables (you can place them in a `.env` file):
+2. Copy the provided `.env.example` to `.env` and fill in your values. The required variables are:
    - `STRAVA_CLIENT_ID`
    - `STRAVA_CLIENT_SECRET`
    - `STRAVA_REDIRECT_URI` (optional, defaults to `http://localhost:5000/callback`)


### PR DESCRIPTION
## Summary
- provide `.env.example` with placeholders and user-provided values
- update setup instructions in `README.md` to copy `.env.example`

## Testing
- `python -m py_compile app.py`
- `python -m py_compile app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68499f4a87748328b5abfd6573231a0a