### PR TITLE
Add favorite segment comparison to dashboard

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -27,6 +27,28 @@
             <li class="list-group-item">{{ r.name }}</li>
           {% endfor %}
         </ul>
+
+        <h2>Segmentos favoritos</h2>
+        <table class="table table-striped mb-4">
+          <thead>
+            <tr>
+              <th>Nombre</th>
+              <th>Tu PR</th>
+              <th>KOM</th>
+              <th>Diferencia</th>
+            </tr>
+          </thead>
+          <tbody>
+          {% for seg in starred_segments %}
+            <tr>
+              <td>{{ seg.name }}</td>
+              <td>{{ seg.pr_time or 'N/A' }}</td>
+              <td>{{ seg.kom_time or 'N/A' }}</td>
+              <td>{% if seg.kom_diff is not none %}{{ seg.kom_diff }} s{% else %}N/A{% endif %}</td>
+            </tr>
+          {% endfor %}
+          </tbody>
+        </table>
       </div>
     </div>
     <h2 class="mt-4">Actividades recientes</h2>


### PR DESCRIPTION
## Summary
- display user's starred segments on dashboard
- show PR time, KOM time and difference for each starred segment

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6849a93f60e08328812753f7cc6f6089