### PR TITLE
Fix variable shadowing in starred segment comparison

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,31 @@ import os
 from flask import Flask, redirect, request, session, url_for, render_template
 import requests
 
+
+def _parse_time_str(t):
+    """Convert a time string like '1:23' or '1:02:03' to seconds."""
+    if not t:
+        return None
+    parts = [int(p) for p in t.split(":")]
+    if len(parts) == 3:
+        h, m, s = parts
+    elif len(parts) == 2:
+        h, m, s = 0, parts[0], parts[1]
+    else:
+        h, m, s = 0, 0, parts[0]
+    return h * 3600 + m * 60 + s
+
+
+def _format_seconds(seconds):
+    """Return a hh:mm:ss string for a number of seconds."""
+    if seconds is None:
+        return None
+    h, rem = divmod(int(seconds), 3600)
+    m, s = divmod(rem, 60)
+    if h:
+        return f"{h}:{m:02d}:{s:02d}"
+    return f"{m}:{s:02d}"
+
 app = Flask(__name__)
 app.secret_key = os.environ.get("SECRET_KEY", "change_me")
 
@@ -43,6 +68,32 @@ def index():
             params={"per_page": 5},
         ).json()
 
+        starred_segments = requests.get(
+            "https://www.strava.com/api/v3/segments/starred",
+            headers=headers,
+            params={"per_page": 5},
+        ).json()
+
+        for seg in starred_segments:
+            pr = None
+            kom_time = None
+
+            seg_stats = seg.get("athlete_segment_stats") or {}
+            pr = seg_stats.get("pr_elapsed_time")
+
+            xoms = seg.get("xoms") or {}
+            kom_str = xoms.get("kom") or xoms.get("qom") or xoms.get("cr")
+            if kom_str:
+                kom_time = _parse_time_str(kom_str)
+
+            if pr is not None and kom_time is not None:
+                seg["kom_diff"] = pr - kom_time
+            else:
+                seg["kom_diff"] = None
+
+            seg["pr_time"] = _format_seconds(pr) if pr is not None else None
+            seg["kom_time"] = _format_seconds(kom_time) if kom_time is not None else None
+
         return render_template(
             "index.html",
             athlete=athlete,
@@ -50,6 +101,7 @@ def index():
             friends=friends,
             routes=routes,
             activities=activities,
+            starred_segments=starred_segments,
         )
     return render_template("index.html", athlete=None)
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -27,6 +27,28 @@
             <li class="list-group-item">{{ r.name }}</li>
           {% endfor %}
         </ul>
+
+        <h2>Segmentos favoritos</h2>
+        <table class="table table-striped mb-4">
+          <thead>
+            <tr>
+              <th>Nombre</th>
+              <th>Tu PR</th>
+              <th>KOM</th>
+              <th>Diferencia</th>
+            </tr>
+          </thead>
+          <tbody>
+          {% for seg in starred_segments %}
+            <tr>
+              <td>{{ seg.name }}</td>
+              <td>{{ seg.pr_time or 'N/A' }}</td>
+              <td>{{ seg.kom_time or 'N/A' }}</td>
+              <td>{% if seg.kom_diff is not none %}{{ seg.kom_diff }} s{% else %}N/A{% endif %}</td>
+            </tr>
+          {% endfor %}
+          </tbody>
+        </table>
       </div>
     </div>
     <h2 class="mt-4">Actividades recientes</h2>


### PR DESCRIPTION
## Summary
- avoid overwriting athlete stats while iterating starred segments
- keep KOM comparison logic using parsed segment data

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6849a93f60e08328812753f7cc6f6089