### PR TITLE
Add horizontal menu with user info

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -6,9 +6,18 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body class="bg-light">
+    <nav class="navbar navbar-expand-lg navbar-light bg-white border-bottom">
+        <div class="container">
+            <a class="navbar-brand" href="/">Strava Metrics</a>
+            <div class="ms-auto d-flex align-items-center">
+                {% block nav_items %}{% endblock %}
+            </div>
+        </div>
+    </nav>
     <div class="container py-4">
         {% block content %}{% endblock %}
     </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@3.8.0/dist/chart.min.js"></script>
     {% block scripts %}{% endblock %}
 </body>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,10 +1,40 @@
+
 {% extends 'base.html' %}
+
+{% block nav_items %}
+  {% if athlete %}
+    <ul class="nav nav-pills me-3" id="menu-tabs" role="tablist">
+      <li class="nav-item" role="presentation">
+        <a class="nav-link active" id="stats-tab" data-bs-toggle="tab" href="#stats" role="tab">Estadísticas</a>
+      </li>
+      <li class="nav-item" role="presentation">
+        <a class="nav-link" id="friends-tab" data-bs-toggle="tab" href="#friends" role="tab">Amigos</a>
+      </li>
+      <li class="nav-item" role="presentation">
+        <a class="nav-link" id="routes-tab" data-bs-toggle="tab" href="#routes" role="tab">Rutas</a>
+      </li>
+      <li class="nav-item" role="presentation">
+        <a class="nav-link" id="segments-tab" data-bs-toggle="tab" href="#segments" role="tab">Segmentos</a>
+      </li>
+      <li class="nav-item" role="presentation">
+        <a class="nav-link" id="activities-tab" data-bs-toggle="tab" href="#activities" role="tab">Actividades</a>
+      </li>
+    </ul>
+    <div class="d-flex align-items-center">
+      <img src="{{ athlete.profile }}" alt="Foto de {{ athlete.firstname }}" class="rounded-circle me-2" width="40" height="40">
+      <span class="me-3">{{ athlete.firstname }} {{ athlete.lastname }}</span>
+      <a class="btn btn-sm btn-danger" href="/logout">Cerrar sesión</a>
+    </div>
+  {% else %}
+      <a class="btn btn-warning" href="/login">Acceder con Strava</a>
+  {% endif %}
+{% endblock %}
 
 {% block content %}
   {% if athlete %}
     <h1 class="mb-4">Bienvenido {{ athlete.firstname }} {{ athlete.lastname }}</h1>
-    <div class="row">
-      <div class="col-md-6">
+    <div class="tab-content" id="menuTabsContent">
+      <div class="tab-pane fade show active" id="stats" role="tabpanel" aria-labelledby="stats-tab">
         <h2>Estadísticas</h2>
         <table class="table table-striped">
           <tr><th>Total actividades en bicicleta</th><td>{{ stats['all_ride_totals']['count'] }}</td></tr>
@@ -14,20 +44,23 @@
         </table>
         <canvas id="distanceChart" height="200"></canvas>
       </div>
-      <div class="col-md-6">
+      <div class="tab-pane fade" id="friends" role="tabpanel" aria-labelledby="friends-tab">
         <h2>Amigos</h2>
         <ul class="list-group mb-4">
           {% for f in friends %}
             <li class="list-group-item">{{ f.firstname }} {{ f.lastname }}</li>
           {% endfor %}
         </ul>
+      </div>
+      <div class="tab-pane fade" id="routes" role="tabpanel" aria-labelledby="routes-tab">
         <h2>Rutas</h2>
         <ul class="list-group mb-4">
           {% for r in routes %}
             <li class="list-group-item">{{ r.name }}</li>
           {% endfor %}
         </ul>
-
+      </div>
+      <div class="tab-pane fade" id="segments" role="tabpanel" aria-labelledby="segments-tab">
         <h2>Segmentos favoritos</h2>
         <table class="table table-striped mb-4">
           <thead>
@@ -50,14 +83,15 @@
           </tbody>
         </table>
       </div>
+      <div class="tab-pane fade" id="activities" role="tabpanel" aria-labelledby="activities-tab">
+        <h2 class="mt-4">Actividades recientes</h2>
+        <ul class="list-group mb-4">
+          {% for a in activities %}
+            <li class="list-group-item">{{ a.name }} - {{ a.distance }} m</li>
+          {% endfor %}
+        </ul>
+      </div>
     </div>
-    <h2 class="mt-4">Actividades recientes</h2>
-    <ul class="list-group mb-4">
-      {% for a in activities %}
-        <li class="list-group-item">{{ a.name }} - {{ a.distance }} m</li>
-      {% endfor %}
-    </ul>
-    <a class="btn btn-danger" href="/logout">Cerrar sesión</a>
   {% else %}
     <h1 class="text-center">Bienvenido a Strava Metrics</h1>
     <p class="text-center">Conecta tu cuenta para comenzar</p>


### PR DESCRIPTION
## Summary
- add Bootstrap nav bar and script support
- add navigation tabs with user info and profile picture
- restructure sections into tab panes

## Testing
- `python -m py_compile app.py`
- *(failed: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6849c3b032248328a48a44771eb2f5fb