### PR TITLE
Add activity type selector

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -10,6 +10,15 @@
         <div class="container">
             <a class="navbar-brand" href="/">Strava Metrics</a>
             <div class="ms-auto d-flex align-items-center">
+                <form action="{{ url_for('set_activity_type') }}" method="post" class="me-3">
+                    <select class="form-select form-select-sm" name="activity_type" onchange="this.form.submit()">
+                        <option value="all" {% if activity_type == 'all' %}selected{% endif %}>Todos</option>
+                        <option value="Ride" {% if activity_type == 'Ride' %}selected{% endif %}>Bicicleta</option>
+                        <option value="Run" {% if activity_type == 'Run' %}selected{% endif %}>Correr</option>
+                        <option value="Tennis" {% if activity_type == 'Tennis' %}selected{% endif %}>Tenis</option>
+                        <option value="Other" {% if activity_type == 'Other' %}selected{% endif %}>Otros</option>
+                    </select>
+                </form>
                 {% block nav_items %}{% endblock %}
             </div>
         </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -85,6 +85,7 @@
       </div>
       <div class="tab-pane fade" id="activities" role="tabpanel" aria-labelledby="activities-tab">
         <h2 class="mt-4">Actividades recientes</h2>
+        <p class="text-muted">Tipo seleccionado: {{ activity_type }}</p>
         <ul class="list-group mb-4">
           {% for a in activities %}
             <li class="list-group-item">{{ a.name }} - {{ a.distance }} m</li>


### PR DESCRIPTION
## Summary
- allow choosing activity type across the site
- filter recent activities by the selected type
- display selected type in activities tab

## Testing
- `python -m py_compile app.py app/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6849c4ce59f48328ab656eca59af03c1