### PR TITLE
Improve segments tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,5 @@ The application requests the `read`, `profile:read_all` and `activity:read` scop
 This command sets up a virtual environment (if needed), installs the dependencies and starts the server. Once running, open `http://localhost:5000` in your browser and click "Connect with Strava".
 
 After authenticating you will see a modern dashboard built with Bootstrap and Chart.js displaying your statistics, a list of friends, your routes and your most recent activities.
+
+You can also choose how many of your starred segments are shown using the selector in the navigation bar.

--- a/app.py
+++ b/app.py
@@ -124,6 +124,16 @@ def set_year():
         session["year"] = datetime.utcnow().year
     return redirect(request.referrer or url_for("index"))
 
+
+@app.route("/set_segments_count", methods=["POST"])
+def set_segments_count():
+    """Store number of starred segments to display and redirect back."""
+    try:
+        session["segments_count"] = int(request.form.get("segments_count", 5))
+    except (TypeError, ValueError):
+        session["segments_count"] = 5
+    return redirect(request.referrer or url_for("index"))
+
 @app.route("/")
 def index():
     if "athlete" in session:
@@ -160,18 +170,18 @@ def index():
         if activity_type != "all":
             activities = [a for a in activities if a.get("type") == activity_type]
 
+        segments_count = session.get("segments_count", 5)
         starred_segments = requests.get(
             "https://www.strava.com/api/v3/segments/starred",
             headers=headers,
-            params={"per_page": 5},
+            params={"per_page": segments_count},
         ).json()
 
         for seg in starred_segments:
             pr = None
             kom_time = None
 
-            seg_stats = seg.get("athlete_segment_stats") or {}
-            pr = seg_stats.get("pr_elapsed_time")
+            pr = seg.get("athlete_pr_effort", {}).get("pr_elapsed_time")
 
             xoms = seg.get("xoms") or {}
             kom_str = xoms.get("kom") or xoms.get("qom") or xoms.get("cr")
@@ -203,10 +213,12 @@ def index():
             years=years,
             selected_year=selected_year,
             months=months,
+            segments_count=segments_count,
         )
     years = list(range(datetime.utcnow().year, datetime.utcnow().year - 5, -1))
     selected_year = session.get("year", datetime.utcnow().year)
     months = MONTHS
+    segments_count = session.get("segments_count", 5)
     return render_template(
         "index.html",
         athlete=None,
@@ -215,6 +227,7 @@ def index():
         selected_year=selected_year,
         year_stats={"count": 0, "distance": 0, "segments": 0, "prs": 0, "monthly_counts": [0]*12},
         months=months,
+        segments_count=segments_count,
     )
 
 @app.route("/login")

--- a/templates/base.html
+++ b/templates/base.html
@@ -26,6 +26,13 @@
                         {% endfor %}
                     </select>
                 </form>
+                <form action="{{ url_for('set_segments_count') }}" method="post" class="me-3">
+                    <select class="form-select form-select-sm" name="segments_count" onchange="this.form.submit()">
+                        {% for n in [5, 10, 20] %}
+                        <option value="{{ n }}" {% if segments_count == n %}selected{% endif %}>{{ n }} segs</option>
+                        {% endfor %}
+                    </select>
+                </form>
                 {% block nav_items %}{% endblock %}
             </div>
         </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -63,6 +63,7 @@
       </div>
       <div class="tab-pane fade" id="segments" role="tabpanel" aria-labelledby="segments-tab">
         <h2>Segmentos favoritos</h2>
+        <p class="text-muted">Mostrando {{ segments_count }} segment{{ 'o' if segments_count == 1 else 'os' }}</p>
         <table class="table table-striped mb-4">
           <thead>
             <tr>


### PR DESCRIPTION
## Summary
- support selecting number of starred segments
- fetch PR time from `athlete_pr_effort` and compute KOM difference correctly
- display how many segments are shown
- document the new selector in README

## Testing
- `python3 -m py_compile app.py app/app.py`

------
https://chatgpt.com/codex/tasks/task_e_684b3096cb8083288bf49d13c9a07f77